### PR TITLE
商品登録の修正

### DIFF
--- a/app/controllers/product_manegements_controller.rb
+++ b/app/controllers/product_manegements_controller.rb
@@ -66,7 +66,7 @@ class ProductManegementsController < ApplicationController
   
   private
   def product_params
-    params.require(:product).permit(:arrival, :successful_bid, :product_name, :product_price, :stock, :unit_price, :shipping_fee, :total_price).merge(status: :exhibit)
+    params.require(:product).permit(:arrival, :successful_bid, :product_name, :product_price, :stock, :unit_price, :shipping_fee, :total_price).merge(status: :exhibit, user_id: current_user.id)
   end
   def update_params
     params.require(:product).permit(:arrival, :successful_bid, :product_name, :product_price, :stock, :unit_price, :shipping_fee, :total_price)

--- a/db/migrate/20191108062056_add_column_to_product.rb
+++ b/db/migrate/20191108062056_add_column_to_product.rb
@@ -2,5 +2,6 @@ class AddColumnToProduct < ActiveRecord::Migration[5.2]
   def change
     add_column :products, :status, :string
     add_column :products, :comment, :text
+    add_column :products, :user_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_083938) do
     t.datetime "updated_at", null: false
     t.string "status"
     t.text "comment"
+    t.integer "user_id"
   end
 
   create_table "sales", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
商品登録の際に登録したユーザーIDを保存する

ユーザーごとに商品を分けるため